### PR TITLE
Add webp support and min image dimension

### DIFF
--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -56,6 +56,7 @@ NS_DEEPZOOM = "http://schemas.microsoft.com/deepzoom/2008"
 
 DEFAULT_RESIZE_FILTER = PIL.Image.LANCZOS
 DEFAULT_IMAGE_FORMAT = "jpg"
+MIN_IMAGE_DIMENSION = 512
 
 RESIZE_FILTERS = {
     "bilinear": PIL.Image.BILINEAR,
@@ -140,8 +141,10 @@ class DeepZoomImageDescriptor(object):
 
     def get_num_tiles(self, level):
         """Number of tiles (columns, rows)"""
-        assert 0 <= level and level < self.num_levels, "Invalid pyramid level"
+        assert 0 <= level < self.num_levels, "Invalid pyramid level"
         w, h = self.get_dimensions(level)
+        if w < MIN_IMAGE_DIMENSION and h < MIN_IMAGE_DIMENSION:
+            return 0, 0
         return (
             int(math.ceil(float(w) / self.tile_size)),
             int(math.ceil(float(h) / self.tile_size)),
@@ -432,22 +435,24 @@ class ImageCreator(object):
         # Create tiles
         image_files = _get_or_create_path(_get_files_path(destination))
         for level in range(self.descriptor.num_levels):
-            level_dir = _get_or_create_path(os.path.join(image_files, str(level)))
-            level_image = self.get_image(level)
-            for (column, row) in self.tiles(level):
-                bounds = self.descriptor.get_tile_bounds(level, column, row)
-                tile = level_image.crop(bounds)
-                format = self.descriptor.tile_format
-                tile_path = os.path.join(level_dir, "%s_%s.%s" % (column, row, format))
-                if self.descriptor.tile_format == "jpg":
-                    jpeg_quality = int(self.image_quality * 100)
-                    tile.save(tile_path, "JPEG", quality=jpeg_quality)
-                elif self.descriptor.tile_format == "webp":
-                    quality = int(self.image_quality * 100)
-                    # See https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp
-                    tile.save(tile_path, "WebP", lossless=True, quality=quality)
-                else:
-                    tile.save(tile_path)
+            tiles = list(self.tiles(level))
+            if tiles:
+                level_dir = _get_or_create_path(os.path.join(image_files, str(level)))
+                level_image = self.get_image(level)
+                for (column, row) in tiles:
+                    bounds = self.descriptor.get_tile_bounds(level, column, row)
+                    tile = level_image.crop(bounds)
+                    format = self.descriptor.tile_format
+                    tile_path = os.path.join(level_dir, "%s_%s.%s" % (column, row, format))
+                    if self.descriptor.tile_format == "jpg":
+                        jpeg_quality = int(self.image_quality * 100)
+                        tile.save(tile_path, "JPEG", quality=jpeg_quality)
+                    elif self.descriptor.tile_format == "webp":
+                        quality = int(self.image_quality * 100)
+                        # See https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp
+                        tile.save(tile_path, "WebP", lossless=True, quality=quality)
+                    else:
+                        tile.save(tile_path)
         # Create descriptor
         self.descriptor.save(destination)
 

--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -450,7 +450,7 @@ class ImageCreator(object):
                     elif self.descriptor.tile_format == "webp":
                         quality = int(self.image_quality * 100)
                         # See https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp
-                        tile.save(tile_path, "WebP", lossless=True, quality=quality)
+                        tile.save(tile_path, "WebP", quality=quality)
                     else:
                         tile.save(tile_path)
         # Create descriptor

--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -67,6 +67,7 @@ RESIZE_FILTERS = {
 IMAGE_FORMATS = {
     "jpg": "jpg",
     "png": "png",
+    "webp": "webp",
 }
 
 
@@ -441,6 +442,10 @@ class ImageCreator(object):
                 if self.descriptor.tile_format == "jpg":
                     jpeg_quality = int(self.image_quality * 100)
                     tile.save(tile_path, "JPEG", quality=jpeg_quality)
+                elif self.descriptor.tile_format == "webp":
+                    quality = int(self.image_quality * 100)
+                    # See https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp
+                    tile.save(tile_path, "WebP", lossless=True, quality=quality)
                 else:
                     tile.save(tile_path)
         # Create descriptor


### PR DESCRIPTION
The goal is to improve performance of non-geosat images tiling.

**Benchmark large_one_color.png 16000x36000px 1.8Mo**

| Format | Interpolation | Duration | Output size | Comment |
| ------- | ------------- | -------- | ------------ | --------- |
| png | bicubic | 39.95s | 8.9Mo | Current |
| png | bilinear | 33.52s | 8.9Mo | |
| jpg 100 | bilinear | 16.63s | 19.5Mo | |
| webp lossless 100 | bicubic | 28.62s | 525Ko | In lossless mode, quality determine time to spend on compression |
| webp lossless 100 | bilinear | 21.85s | 525Ko | |
| webp lossless 0 | bilinear | 23.31s | 734Ko | |
| webp 100 | bilinear | 30.87s | 2.3Mo | |
| webp 80 | bilinear | 30.89s | 2.4Mo | |
| webp lossless 100 | bilinear | 17.20s | 524Ko | With min image dimension of 512px |

Overall gain of **57%** on duration and **94%** on output size.

**Benchmark Big_&_Small_Pumkins.jpeg 12000x8000px 12.4Mo (with min image dimension of 512px)**

| Format | Interpolation | Duration | Output size | Comment |
| ------- | ------------- | -------- | ------------ | --------- |
| png | bicubic | 39.88s | 110,2Mo | Current |
| webp lossless 100 | bilinear | 210.08s | 72,3Mo | |
| webp lossless 0 | bilinear | 46.47s | 79,5Mo | |
| webp 100 | bilinear | 9.05s | 23,1Mo | |
| webp 100 | bicubic | 9.15s | 24,1Mo | |
| webp 80 | bilinear | 6.76s | 5,2Mo | |
