### PR TITLE
Free memory when image objects no more used

### DIFF
--- a/deepzoom/__init__.py
+++ b/deepzoom/__init__.py
@@ -453,8 +453,12 @@ class ImageCreator(object):
                         tile.save(tile_path, "WebP", quality=quality)
                     else:
                         tile.save(tile_path)
+                    tile.close()
+                if level_image != self.image:
+                    level_image.close()
         # Create descriptor
         self.descriptor.save(destination)
+        self.image.close()
 
 
 class CollectionCreator(object):


### PR DESCRIPTION
Currently the image objects used during the tiling process are never released , so the memory footprint is higher than necessary.